### PR TITLE
Add simple test plugin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-test
+# Cloudflare unRAID Plugin (Test)
+
+This repository contains a simple unRAID plugin skeleton for Cloudflare-related features.
+
+## Installing on unRAID
+
+Download the plugin file to your unRAID server and install it:
+
+```bash
+wget -O /boot/config/plugins/cloudflare.plg https://raw.githubusercontent.com/yourusername/unraid-cloudflare-ui/main/plugin.plg
+installplg /boot/config/plugins/cloudflare.plg
+```
+
+This test plugin installs a basic PHP page and helper script.

--- a/plugin.plg
+++ b/plugin.plg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PLUGIN name="cloudflare" author="Your Name" version="0.1" pluginURL="https://github.com/yourusername/unraid-cloudflare-ui">
+  <CHANGES>
+    Initial test release.
+  </CHANGES>
+
+  <FILE Name="/usr/local/emhttp/plugins/cloudflare/scripts/cloudflare.sh">
+    <URL>https://raw.githubusercontent.com/yourusername/unraid-cloudflare-ui/main/usr/local/emhttp/plugins/cloudflare/scripts/cloudflare.sh</URL>
+    <MD5></MD5>
+  </FILE>
+
+  <FILE Name="/usr/local/emhttp/plugins/cloudflare/index.php">
+    <URL>https://raw.githubusercontent.com/yourusername/unraid-cloudflare-ui/main/usr/local/emhttp/plugins/cloudflare/index.php</URL>
+    <MD5></MD5>
+  </FILE>
+</PLUGIN>

--- a/usr/local/emhttp/plugins/cloudflare/index.php
+++ b/usr/local/emhttp/plugins/cloudflare/index.php
@@ -1,0 +1,3 @@
+<?php
+  echo "<h1>Cloudflare Plugin Test</h1>";
+?>

--- a/usr/local/emhttp/plugins/cloudflare/scripts/cloudflare.sh
+++ b/usr/local/emhttp/plugins/cloudflare/scripts/cloudflare.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Cloudflare helper script"


### PR DESCRIPTION
## Summary
- set up `cloudflare` test plugin with minimal script and index page
- include plugin descriptor and installation instructions

## Testing
- `bash usr/local/emhttp/plugins/cloudflare/scripts/cloudflare.sh`
- `php -l usr/local/emhttp/plugins/cloudflare/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68954233dcf083239f95365ed08978c1