### PR TITLE
Render simple webpage at plugin endpoint

### DIFF
--- a/plugin.plg
+++ b/plugin.plg
@@ -9,8 +9,8 @@
     <MD5>19f9a1fa46ed699202403e62de151854</MD5>
   </FILE>
 
-  <FILE Name="/usr/local/emhttp/plugins/cloudflare/index.php">
-    <URL>https://raw.githubusercontent.com/masonbesmer/unraid-cloudflare-ui/main/usr/local/emhttp/plugins/cloudflare/index.php</URL>
-    <MD5>c0b2f13550d107fa83690a6ceaaa1fc8</MD5>
+  <FILE Name="/usr/local/emhttp/plugins/cloudflare/index.html">
+    <URL>https://raw.githubusercontent.com/masonbesmer/unraid-cloudflare-ui/main/usr/local/emhttp/plugins/cloudflare/index.html</URL>
+    <MD5>4d4f47bbfc45ab1a8603bc61de4daccb</MD5>
   </FILE>
 </PLUGIN>

--- a/usr/local/emhttp/plugins/cloudflare/index.html
+++ b/usr/local/emhttp/plugins/cloudflare/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cloudflare Plugin</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Cloudflare Plugin</h1>
+    <p>This is a simple website served from the Cloudflare plugin.</p>
+  </body>
+</html>

--- a/usr/local/emhttp/plugins/cloudflare/index.php
+++ b/usr/local/emhttp/plugins/cloudflare/index.php
@@ -1,3 +1,0 @@
-<?php
-  echo "<h1>Cloudflare Plugin Test</h1>";
-?>


### PR DESCRIPTION
## Summary
- Serve static index.html so /plugins/cloudflare/ loads without a 403
- Update plugin manifest to reference new index page

## Testing
- `tidy -q -e usr/local/emhttp/plugins/cloudflare/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68956b2bd0c883238bf2b6745d602ddb